### PR TITLE
Issue #52 : Popravljanje bagova

### DIFF
--- a/hardware/design/register_file.vhd
+++ b/hardware/design/register_file.vhd
@@ -201,7 +201,7 @@ begin
         elsif (counter_rise = 2 and address_index /= 6) or
         (counter_rise = 0 and address_index = 6) then
           reg_file(1)(4) <= '1';
-          counter_fall <= 0;
+          counter_rise <= 0;
         else
           reg_file(address_index) <= av_writedata_i;
           if address_index = 3 or address_index = 4 then
@@ -236,7 +236,7 @@ begin
       -- Send data to FIFO buffer when both registers are ready
       if counter_fall = 4 then
         counter_fall <= 0;
-        if reg_file(3) < timer_output(63 downto 32) then
+        if (reg_file(3) & reg_file(4)) < timer_output then
           reg_file(1)(0) <= '1';
         else
           fifo_write_data(95 downto 64) <= reg_file(3);
@@ -246,7 +246,7 @@ begin
         end if;
       elsif counter_rise = 4 then
         counter_rise <= 0;
-        if reg_file(5) < timer_output(63 downto 32) then
+        if (reg_file(5) & reg_file(6)) < timer_output then
           reg_file(1)(0) <= '1';
         else
           fifo_write_data(95 downto 64) <= reg_file(5);

--- a/hardware/tests/atomic_access_tb.vhd
+++ b/hardware/tests/atomic_access_tb.vhd
@@ -99,7 +99,7 @@ begin
         write_bus(net, avmm_bus, std_logic_vector(to_unsigned(4, address'length)), std_logic_vector(to_unsigned(1337, address'length)));
 		wait_until_idle(net, avmm_bus);
 
-        wait for 2*T;
+        wait for T;
 
         read_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), readdata_temp);
         wait_until_idle(net, avmm_bus);
@@ -129,7 +129,7 @@ begin
         write_bus(net, avmm_bus, std_logic_vector(to_unsigned(6, address'length)), std_logic_vector(to_unsigned(1337, address'length)));
 		wait_until_idle(net, avmm_bus);
 
-        wait for 2*T;
+        wait for T;
 
         read_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), readdata_temp);
         wait_until_idle(net, avmm_bus);
@@ -159,6 +159,12 @@ begin
         write_bus(net, avmm_bus, std_logic_vector(to_unsigned(6, address'length)), std_logic_vector(to_unsigned(1520, address'length)));
 		wait_until_idle(net, avmm_bus);
 
+		-- Clear status register
+		write_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), std_logic_vector(to_unsigned(0, address'length)));
+		wait_until_idle(net, avmm_bus);
+
+		wait for T;
+
         read_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), readdata_temp);
         wait_until_idle(net, avmm_bus);
 
@@ -169,7 +175,7 @@ begin
         write_bus(net, avmm_bus, std_logic_vector(to_unsigned(4, address'length)), std_logic_vector(to_unsigned(1520, address'length)));
 		wait_until_idle(net, avmm_bus);
 
-        wait for 2*T;
+        wait for T;
 
         read_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), readdata_temp);
         wait_until_idle(net, avmm_bus);
@@ -180,7 +186,7 @@ begin
         write_bus(net, avmm_bus, std_logic_vector(to_unsigned(6, address'length)), std_logic_vector(to_unsigned(1520, address'length)));
 		wait_until_idle(net, avmm_bus);
 
-        wait for 2*T;
+        wait for T;
 
         read_bus(net, avmm_bus, std_logic_vector(to_unsigned(1, address'length)), readdata_temp);
         wait_until_idle(net, avmm_bus);


### PR DESCRIPTION
- Popravljen bag u register_file prilikom greške u atomskog pristupu kod koga se pogrešan brojač resetovao
- Popravljen bag koji poredi vrijeme unesenog timestamp-a sa trenutnim, umjesto da se porede samo unix vremena, sada se porede vremena u punoj preciznosti
- Izmjene u atomic_access_tb fajlu tako da se prilagode potrebi da se statusni registar uvijek mora očistiti od strane korisnika